### PR TITLE
Small change to encoder element.

### DIFF
--- a/src/main/xsd/logback.xsd
+++ b/src/main/xsd/logback.xsd
@@ -146,7 +146,8 @@
 
 	<xsd:complexType name="Encoder">
 		<xsd:sequence>
-			<xsd:element name="pattern" type="xsd:string"/>
+			<xsd:element name="pattern" type="xsd:string" minOccurs="0" minOccurs="1" />
+			<xsd:element name="layout" minOccurs="0" maxOccurs="1" type="Layout" />
 		</xsd:sequence>
 		<xsd:attribute name="class" type="xsd:string" use="optional"/>
 	</xsd:complexType>


### PR DESCRIPTION
Thanks for the project!    I have logback.xml that does not have a pattern in the <encoder> section:

                <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
                        <layout class="ch.qos.logback.classic.PatternLayout">
                                <param name="Pattern" value="%date{HH:mm:ss.SSS}::%-4relative::%thread::%-5level::%c::%msg%n" />
                        </layout>
                </encoder>
