### PR TITLE
Added missing Encoder properties

### DIFF
--- a/src/main/xsd/logback.xsd
+++ b/src/main/xsd/logback.xsd
@@ -150,6 +150,7 @@
 			<xsd:element name="layout" minOccurs="0" maxOccurs="1" type="Layout" />
 			<xsd:element name="immediateFlush" type="xsd:boolean" minOccurs="0" maxOccurs="1" />
 			<xsd:element name="outputPatternAsHeader" type="xsd:boolean" minOccurs="0" maxOccurs="1" />
+			<xsd:element name="charset" type="xsd:string" minOccurs="0" maxOccurs="1" />
 		</xsd:choice>
 		<xsd:attribute name="class" type="xsd:string" use="optional"/>
 	</xsd:complexType>

--- a/src/main/xsd/logback.xsd
+++ b/src/main/xsd/logback.xsd
@@ -145,9 +145,11 @@
 	</xsd:complexType>
 
 	<xsd:complexType name="Encoder">
-		<xsd:sequence>
+		<xsd:choice maxOccurs="unbounded">
 			<xsd:element name="pattern" type="xsd:string"/>
-		</xsd:sequence>
+			<xsd:element name="immediateFlush" type="xsd:boolean" minOccurs="0" maxOccurs="1" />
+			<xsd:element name="outputPatternAsHeader" type="xsd:boolean" minOccurs="0" maxOccurs="1" />
+		</xsd:choice>
 		<xsd:attribute name="class" type="xsd:string" use="optional"/>
 	</xsd:complexType>
 

--- a/src/main/xsd/logback.xsd
+++ b/src/main/xsd/logback.xsd
@@ -146,7 +146,8 @@
 
 	<xsd:complexType name="Encoder">
 		<xsd:choice maxOccurs="unbounded">
-			<xsd:element name="pattern" type="xsd:string"/>
+			<xsd:element name="pattern" type="xsd:string" minOccurs="0" minOccurs="1" />
+			<xsd:element name="layout" minOccurs="0" maxOccurs="1" type="Layout" />
 			<xsd:element name="immediateFlush" type="xsd:boolean" minOccurs="0" maxOccurs="1" />
 			<xsd:element name="outputPatternAsHeader" type="xsd:boolean" minOccurs="0" maxOccurs="1" />
 		</xsd:choice>

--- a/src/main/xsd/logback.xsd
+++ b/src/main/xsd/logback.xsd
@@ -146,7 +146,7 @@
 
 	<xsd:complexType name="Encoder">
 		<xsd:choice maxOccurs="unbounded">
-			<xsd:element name="pattern" type="xsd:string" minOccurs="0" minOccurs="1" />
+			<xsd:element name="pattern" type="xsd:string" minOccurs="0" maxOccurs="1" />
 			<xsd:element name="layout" minOccurs="0" maxOccurs="1" type="Layout" />
 			<xsd:element name="immediateFlush" type="xsd:boolean" minOccurs="0" maxOccurs="1" />
 			<xsd:element name="outputPatternAsHeader" type="xsd:boolean" minOccurs="0" maxOccurs="1" />


### PR DESCRIPTION
Added immediateFlush and outputPatternAsHeader properties as shown on
http://logback.qos.ch/manual/encoders.html#PatternLayoutEncoder

Switched from xsd:sequence to xsd:choice