### PR TITLE
Allow <appender-ref> in <appender>, merge improvements from nkatsar

### DIFF
--- a/src/main/xsd/logback.xsd
+++ b/src/main/xsd/logback.xsd
@@ -147,9 +147,11 @@
 	</xsd:complexType>
 
 	<xsd:complexType name="Encoder">
-		<xsd:sequence>
+		<xsd:choice maxOccurs="unbounded">
 			<xsd:element name="pattern" type="xsd:string"/>
-		</xsd:sequence>
+			<xsd:element name="immediateFlush" type="xsd:boolean" minOccurs="0" maxOccurs="1" />
+			<xsd:element name="outputPatternAsHeader" type="xsd:boolean" minOccurs="0" maxOccurs="1" />
+		</xsd:choice>
 		<xsd:attribute name="class" type="xsd:string" use="optional"/>
 	</xsd:complexType>
 

--- a/src/main/xsd/logback.xsd
+++ b/src/main/xsd/logback.xsd
@@ -111,6 +111,7 @@
 			<xsd:element name="rollingPolicy" minOccurs="0" maxOccurs="1" type="RollingPolicy"/>
 			<xsd:element name="connectionSource" minOccurs="0" maxOccurs="1" type="ConnectionSource" />
 			<xsd:element name="triggeringPolicy" minOccurs="0" maxOccurs="1" type="TriggeringPolicy" />
+			<xsd:element name="appender-ref" minOccurs="0" maxOccurs="1" type="AppenderRef"/>
 			<xsd:any namespace="##other" processContents="skip" minOccurs="0" maxOccurs="unbounded"/>
 		</xsd:choice>
 		<xsd:attribute name="name" type="xsd:string" use="required"/>

--- a/src/main/xsd/logback.xsd
+++ b/src/main/xsd/logback.xsd
@@ -187,15 +187,15 @@
 			</xsd:simpleType>
 			<xsd:simpleType>
 				<xsd:restriction base="xsd:string">
-					<xsd:pattern value="[Oo][Ff]{2}"/>
-					<xsd:pattern value="[Aa][Ll]{2}"/>
-					<xsd:pattern value="[Ii][Nn][Hh][Ee][Rr][Ii][Tt][Ee][Dd]"/>
-					<xsd:pattern value="[Nn][Uu][Ll]{2}"/>
-					<xsd:pattern value="[Ee][Rr]{2}[Oo][Rr]"/>
-					<xsd:pattern value="[Ww][Aa][Rr][Nn]"/>
-					<xsd:pattern value="[Ii][Nn][Ff][Oo]"/>
-					<xsd:pattern value="[Dd][Ee][Bb][Uu][Gg]"/>
-					<xsd:pattern value="[Tt][Rr][Aa][Cc][Ee]"/>
+					<xsd:pattern value="($\{.+:-)?[Oo][Ff]{2}\}?"/>
+					<xsd:pattern value="($\{.+:-)?[Aa][Ll]{2}\}?"/>
+					<xsd:pattern value="($\{.+:-)?[Ii][Nn][Hh][Ee][Rr][Ii][Tt][Ee][Dd]\}?"/>
+					<xsd:pattern value="($\{.+:-)?[Nn][Uu][Ll]{2}\}?"/>
+					<xsd:pattern value="($\{.+:-)?[Ee][Rr]{2}[Oo][Rr]\}?"/>
+					<xsd:pattern value="($\{.+:-)?[Ww][Aa][Rr][Nn]\}?"/>
+					<xsd:pattern value="($\{.+:-)?[Ii][Nn][Ff][Oo]\}?"/>
+					<xsd:pattern value="($\{.+:-)?[Dd][Ee][Bb][Uu][Gg]\}?"/>
+					<xsd:pattern value="($\{.+:-)?[Tt][Rr][Aa][Cc][Ee]\}?"/>
 				</xsd:restriction>
 			</xsd:simpleType>
 		</xsd:union>

--- a/src/main/xsd/logback.xsd
+++ b/src/main/xsd/logback.xsd
@@ -148,7 +148,7 @@
 
 	<xsd:complexType name="Encoder">
 		<xsd:choice maxOccurs="unbounded">
-			<xsd:element name="pattern" type="xsd:string" minOccurs="0" minOccurs="1" />
+			<xsd:element name="pattern" type="xsd:string" minOccurs="0" maxOccurs="1" />
 			<xsd:element name="layout" minOccurs="0" maxOccurs="1" type="Layout" />
 			<xsd:element name="immediateFlush" type="xsd:boolean" minOccurs="0" maxOccurs="1" />
 			<xsd:element name="outputPatternAsHeader" type="xsd:boolean" minOccurs="0" maxOccurs="1" />

--- a/src/main/xsd/logback.xsd
+++ b/src/main/xsd/logback.xsd
@@ -152,6 +152,7 @@
 			<xsd:element name="layout" minOccurs="0" maxOccurs="1" type="Layout" />
 			<xsd:element name="immediateFlush" type="xsd:boolean" minOccurs="0" maxOccurs="1" />
 			<xsd:element name="outputPatternAsHeader" type="xsd:boolean" minOccurs="0" maxOccurs="1" />
+			<xsd:element name="charset" type="xsd:string" minOccurs="0" maxOccurs="1" />
 		</xsd:choice>
 		<xsd:attribute name="class" type="xsd:string" use="optional"/>
 	</xsd:complexType>

--- a/src/main/xsd/logback.xsd
+++ b/src/main/xsd/logback.xsd
@@ -148,7 +148,8 @@
 
 	<xsd:complexType name="Encoder">
 		<xsd:choice maxOccurs="unbounded">
-			<xsd:element name="pattern" type="xsd:string"/>
+			<xsd:element name="pattern" type="xsd:string" minOccurs="0" minOccurs="1" />
+			<xsd:element name="layout" minOccurs="0" maxOccurs="1" type="Layout" />
 			<xsd:element name="immediateFlush" type="xsd:boolean" minOccurs="0" maxOccurs="1" />
 			<xsd:element name="outputPatternAsHeader" type="xsd:boolean" minOccurs="0" maxOccurs="1" />
 		</xsd:choice>

--- a/src/main/xsd/logback.xsd
+++ b/src/main/xsd/logback.xsd
@@ -38,6 +38,7 @@
 	</xsd:complexType>
 
 	<xsd:complexType name="Include">
+		<xsd:attribute name="optional" use="optional" type="xsd:boolean"/>
 		<xsd:attribute name="file" use="optional" type="xsd:string"/>
 		<xsd:attribute name="resource" use="optional" type="xsd:string"/>
 		<xsd:attribute name="url" use="optional" type="xsd:string"/>


### PR DESCRIPTION
This PR merges changes from nkatsar/logback-XSD fork and adds one my change that allows <appender-ref> in <appender> elements.

Thanks to @nkatsar, @rtack and @petteyg for their contributions!