### PR TITLE
Added some missed standard tags support

### DIFF
--- a/src/main/xsd/logback.xsd
+++ b/src/main/xsd/logback.xsd
@@ -127,6 +127,8 @@
 	<xsd:complexType name="Filter">
 		<xsd:choice maxOccurs="unbounded">
 			<xsd:element name="level" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+			<xsd:element name="OnMatch" minOccurs="0" maxOccurs="unbounded" type="MatchValues"/>
+			<xsd:element name="OnMismatch" minOccurs="0" maxOccurs="unbounded" type="MatchValues"/>
       <xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
 		</xsd:choice>
 		<xsd:attribute name="class" type="xsd:string" use="optional"/>
@@ -172,6 +174,13 @@
 	<xsd:complexType name="AppenderRef">
 		<xsd:attribute name="ref" type="xsd:string"/>
 	</xsd:complexType>
+
+	<xsd:simpleType name="MatchValues">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="ACCEPT"/>
+			<xsd:enumeration value="DENY" />
+		</xsd:restriction>
+	</xsd:simpleType>
 
 	<xsd:simpleType name="LoggerLevels">
 		<xsd:union>

--- a/src/main/xsd/logback.xsd
+++ b/src/main/xsd/logback.xsd
@@ -4,6 +4,7 @@
 
 	<xsd:complexType name="Configuration">
 		<xsd:choice maxOccurs="unbounded">
+			<xsd:element name="shutdownHook" minOccurs="0" maxOccurs="1" type="ShutdownHook"/>
 			<xsd:element name="statusListener" minOccurs="0" maxOccurs="unbounded" type="StatusListener"/>
 			<xsd:element name="contextListener" minOccurs="0" maxOccurs="unbounded" type="ContextListener"/>
 			<xsd:element name="include" minOccurs="0" maxOccurs="unbounded" type="Include"/>
@@ -20,6 +21,12 @@
 		<xsd:attribute name="debug" type="xsd:boolean" use="optional"/>
 		<xsd:attribute name="scan" type="xsd:string" use="optional"/>
 		<xsd:attribute name="scanPeriod" type="xsd:string" use="optional"/>
+		<xsd:anyAttribute/>
+	</xsd:complexType>
+
+	<xsd:complexType name="ShutdownHook">
+		<xsd:attribute name="class" type="xsd:string" use="optional"
+					   default="ch.qos.logback.core.hook.DelayingShutdownHook"/>
 		<xsd:anyAttribute/>
 	</xsd:complexType>
 
@@ -149,6 +156,7 @@
 	<xsd:complexType name="Encoder">
 		<xsd:sequence>
 			<xsd:element name="pattern" type="xsd:string"/>
+			<xsd:element name="immediateFlush" type="xsd:boolean"/>
 		</xsd:sequence>
 		<xsd:attribute name="class" type="xsd:string" use="optional"/>
 	</xsd:complexType>


### PR DESCRIPTION
Added some missed standard tags support. 
If you are interested, I will try to fill all the cases of the standard documentation

Changelog:
- shutdownHooks support added.
- OnMismatch/OnMatch tags added (using for filter's level)