### PR TITLE
fix so LoggerLevels type allows ${foo} values, e.g. level="${test.logLevel:-info}"

### DIFF
--- a/src/main/xsd/logback.xsd
+++ b/src/main/xsd/logback.xsd
@@ -170,14 +170,23 @@
 			<xsd:simpleType>
 				<xsd:restriction base="xsd:string">
 					<xsd:enumeration value="OFF"/>
+					<xsd:enumeration value="off"/>
 					<xsd:enumeration value="ALL"/>
+					<xsd:enumeration value="all"/>
 					<xsd:enumeration value="INHERITED"/>
+					<xsd:enumeration value="inherited"/>
 					<xsd:enumeration value="NULL"/>
+					<xsd:enumeration value="null"/>
 					<xsd:enumeration value="ERROR"/>
+					<xsd:enumeration value="error"/>
 					<xsd:enumeration value="WARN"/>
+					<xsd:enumeration value="warn"/>
 					<xsd:enumeration value="INFO"/>
+					<xsd:enumeration value="info"/>
 					<xsd:enumeration value="DEBUG"/>
+					<xsd:enumeration value="debug"/>
 					<xsd:enumeration value="TRACE"/>
+					<xsd:enumeration value="trace"/>
 				</xsd:restriction>
 			</xsd:simpleType>
 			<xsd:simpleType>

--- a/src/main/xsd/logback.xsd
+++ b/src/main/xsd/logback.xsd
@@ -191,6 +191,7 @@
 					<xsd:pattern value="[Ii][Nn][Ff][Oo]"/>
 					<xsd:pattern value="[Dd][Ee][Bb][Uu][Gg]"/>
 					<xsd:pattern value="[Tt][Rr][Aa][Cc][Ee]"/>
+					<xsd:pattern value="\$\{.+\}"/>
 				</xsd:restriction>
 			</xsd:simpleType>
 		</xsd:union>


### PR DESCRIPTION
This is a fix for issue #28. It worked for me in IntelliJ.