### PR TITLE
set `scan` attribute to `boolean` type

### DIFF
--- a/src/main/xsd/logback.xsd
+++ b/src/main/xsd/logback.xsd
@@ -33,7 +33,7 @@
 			<xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
 		</xsd:choice>
 		<xsd:attribute name="debug" type="xsd:boolean" use="optional"/>
-		<xsd:attribute name="scan" type="xsd:string" use="optional"/>
+		<xsd:attribute name="scan" type="xsd:boolean" use="optional"/>
 		<xsd:attribute name="scanPeriod" type="xsd:string" use="optional"/>
 		<xsd:attribute name="packagingData" type="xsd:boolean" use="optional"/>
 		<xsd:anyAttribute/>


### PR DESCRIPTION
Logback only check if the value of the 'scan' attribute is 'false', so it  should be a boolean. 
Here are code snippets in `ch.qos.logback.classic.joran.action.ConfigurationAction`
```
String scanAttrib = ic.subst(attributes.getValue("scan"));
        if (!OptionHelper.isEmpty(scanAttrib) && !"false".equalsIgnoreCase(scanAttrib))
```