### PR TITLE
Added Scope for property

### DIFF
--- a/src/main/xsd/logback.xsd
+++ b/src/main/xsd/logback.xsd
@@ -129,6 +129,7 @@
 		<xsd:sequence>
 			<xsd:any minOccurs="0" maxOccurs="unbounded"/>
 		</xsd:sequence>
+		<xsd:attribute name="scope" type="xsd:string" use="optional"/>
 		<xsd:attribute name="name" type="xsd:string" use="optional"/>
 		<xsd:attribute name="value" type="xsd:string" use="optional"/>
 		<xsd:attribute name="file" type="xsd:string" use="optional"/>


### PR DESCRIPTION
Added `scope` for the type `Property`

To be used like follows.

```xml
<property scope="context" name="COLORIZER_COLORS" value="red@,yellow@,blue@,green@,cyan@"/>
```